### PR TITLE
fixes for MSVC 14.1, aka VS 2017

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.1.0)
 
+project(serialdv)
+
+option(BUILD_TOOL "Build dvtest tool" ON)
+
 # use, i.e. don't skip the full RPATH for the build tree
 set(CMAKE_SKIP_BUILD_RPATH  FALSE)
 
@@ -21,9 +25,12 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 #list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
 
 # Compiler flags.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -O2 -ffast-math -ftree-vectorize ${EXTRA_FLAGS}")
-
-project(serialdv)
+if(WIN32)
+  add_definitions(-D__WINDOWS__)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall ${EXTRA_FLAGS}")
+else()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -O2 -ffast-math -ftree-vectorize ${EXTRA_FLAGS}")
+endif()
 
 set(serialdv_SOURCES
   serialdatacontroller.cpp
@@ -45,6 +52,7 @@ add_library(serialdv SHARED
     ${serialdv_SOURCES}
 )
 
+if(BUILD_TOOL)
 add_executable(dvtest
     dvtest.cpp
 )
@@ -57,5 +65,7 @@ target_include_directories(dvtest PUBLIC
 target_link_libraries(dvtest serialdv)
 
 install(TARGETS dvtest DESTINATION bin)
+endif(BUILD_TOOL)
+
 install(TARGETS serialdv DESTINATION lib)
 install(FILES ${serialdv_HEADERS} DESTINATION include/${PROJECT_NAME})

--- a/serialdatacontroller.cpp
+++ b/serialdatacontroller.cpp
@@ -70,7 +70,7 @@ bool SerialDataController::open(const std::string& device, SERIAL_SPEED speed)
 
     DWORD errCode;
 
-    m_handle = ::CreateFile((const wchar_t*) m_device.c_str(), GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, FILE_FLAG_OVERLAPPED, NULL);
+    m_handle = ::CreateFile(m_device.c_str(), GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, FILE_FLAG_OVERLAPPED, NULL);
     if (m_handle == INVALID_HANDLE_VALUE)
     {
         fprintf(stderr, "Cannot open device - %s, err=%04lx\n", m_device.c_str(), ::GetLastError());


### PR DESCRIPTION
- move project ahead to avoid compiler tests failure
- add option BUILD_TOOL to disable dvtest
- remove CXX_FLAGS not compatible with MSVC
- add __WINDOWS__ as compiler definition because not defined
- remove (const wchar_t*)  error C2664
  tested on windows and ubuntu 16.04 (no warning)